### PR TITLE
Update makefile for optimizations and support GNU fortran

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,38 +1,33 @@
+#This part is for ifort
 FOR=ifort
 OMP=-qopenmp
 LIBS=-qmkl
 EXTRA= -shared-intel
+COND=-fpp
+#Uncomment to add optimizations (-O2 is ifort's default behavior)
+#FFLAGS= -O2 -xHOST 
+
+#Uncomment this part to use GNU fortran compiler
+#FOR=gfortran
+#OMP=-fopenmp
+#LIBS= -L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_gf_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl  -m64  -I"${MKLROOT}/include"
+#COND=-x f95-cpp-input
+#FFLAGS=-O2 -march=native
+
+
 DIR="./bin/"
-COND=-fpp 
 
-all :
-	
-	$(FOR) wtb_main.f90 -o $(DIR)wtb.x $(LIBS) $(OMP) $(COND)
-	$(FOR) wtb_main.f90 -o $(DIR)wtbf.x $(LIBS) $(OMP) $(COND)-DFAST1	
-	$(FOR) ./utils/nc_nv_finder.f90 -o $(DIR)nc_nv_finder.x $(OMP) $(LIBS)
-	$(FOR) ./utils/param_gen.f90  -o $(DIR)param_gen.x
-	$(FOR) ./utils/param_gen_vasp.f90  -o $(DIR)param_gen_vasp.x
-	$(FOR) ./utils/dirgapf.f90  -o $(DIR)dirgapf.x	
-
-
-
-
+all :	main pp
 
 main :
-	$(FOR) wtb_main.f90 -o $(DIR)wtb.x $(LIBS) $(OMP) $(COND)
-	$(FOR) wtb_main.f90 -o $(DIR)wtbf.x $(LIBS) $(OMP) $(COND)-DFAST1		
-
+	$(FOR) $(FFLAGS) $(COND) wtb_main.f90 -o $(DIR)wtb.x $(LIBS) $(OMP)
+	$(FOR) $(FFLAGS) $(COND) wtb_main.f90 -o $(DIR)wtbf.x $(LIBS) $(OMP) -DFAST1
 
 pp :
-	$(FOR) ./utils/nc_nv_finder.f90 -o $(DIR)nc_nv_finder.x $(OMP) $(LIBS)
-	$(FOR) ./utils/param_gen.f90  -o $(DIR)param_gen.x
-	$(FOR) ./utils/param_gen_vasp.f90  -o $(DIR)param_gen_vasp.x
-	$(FOR) ./utils/dirgapf.f90  -o $(DIR)dirgapf.x
- 
+	$(FOR) $(FFLAGS) ./utils/nc_nv_finder.f90 -o $(DIR)nc_nv_finder.x $(OMP) $(LIBS)
+	$(FOR) $(FFLAGS) ./utils/param_gen.f90  -o $(DIR)param_gen.x
+	$(FOR) $(FFLAGS) ./utils/param_gen_vasp.f90  -o $(DIR)param_gen_vasp.x
+	$(FOR) $(FFLAGS) ./utils/dirgapf.f90  -o $(DIR)dirgapf.x
 
 test :
-	$(FOR) wtb_main.f90 -o $(DIR)wtb.x $(LIBS) $(OMP) $(COND)
-	
-
-
- 
+	$(FOR) $(FFLAGS) $(COND) wtb_main.f90 -o $(DIR)wtb.x $(LIBS) $(OMP)


### PR DESCRIPTION
tested with gcc version 4.8.5 20150623 (Red Hat 4.8.5-44) (GCC)

removed unnecessary codes from makefile
added hardware specific optimizations