### PR TITLE
Update makefile.inc:  Update compiler to `ifx` and use `-xHOST` for S…

### DIFF
--- a/makefile.inc
+++ b/makefile.inc
@@ -1,6 +1,9 @@
-FOR=ifort
-OMP=-qopenmp -shared-intel 
+FOR=ifx
+OMP=-qopenmp -shared-intel
 LIBS=-qmkl
 EXTRA= -DMKL
 DIR="./bin/"
-COND=-fpp -O2
+
+## -O3 can be used
+
+COND=-fpp -O2 -fp-model fast=2 -xHOST


### PR DESCRIPTION
### **Description**

This pull request updates our build process to make the code run faster on modern computers.

1.  **New Compiler:** We are switching from the old `ifort` compiler to the new `ifx` compiler from Intel.
2.  **Better Optimization:** We are now using the `-xHOST` flag.

---

### **What These Changes Mean**

* **`ifx`**: This is Intel's modern compiler, replacing `ifort` in new versions of Intel OneAPI. It is designed to improve the performance of new CPUs using LLVM as the compiler.
* **`-O3`**: This tells the compiler to optimize the code for maximum speed during compilation. No significant increase in compilation time or memory requirements was identified.
* **`-fp-model fast=2`**: This allows the compiler to perform faster mathematical calculations in certain scenarios.
    * **Warning:** This can cause very small differences in the final numbers, which are often insignificant. In local tests, this was *not* identified, however, further testing is required.
* **`-xHOST`**: This is the most important change. It instructs the compiler to 'look at the CPU I am compiling on and use 100% of its special features'.
    * **Benefits:** This gives you the fastest possible program for your specific machine. For example, it makes use of vectorization flags such as AVX, which the MKL libraries can take advantage of.
    * **Warning:** The program created **will not run on older computers.** It only works on computers that have the same CPU as yours, or a newer one.

---

### **How to Compile for Other Computers**

If you need to compile a program that can run on *other* (or older) computers, you must replace `-xHOST` with a specific flag.

Here are the most common options:

* **For most modern CPUs (Intel & AMD from ~2013+):**
    > Use `-xCORE-AVX2`
    > This is the safest, most compatible option for modern hardware.

* **For very new CPUs (Intel & AMD with AVX-512, from ~2022+):**
    > Use `-xCORE-AVX512` or  `-xSKYLAKE-AVX512`
    > This is faster but will only run on the very newest machines (like AMD Zen 4 or Intel Sapphire Rapids).


Tests were performed on the following machines:

- MacBook Air M1 (ARM)
- Gentoo GNU/Linux (AMD64, AMD Ryzen 5800X3D)

Intel OneAPI 2024.2 was used in both cases.

I will prepare a file containing benchmarks and other statistics.