### PR TITLE
Update makefile.inc + makefiie

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,93 +1,127 @@
 include makefile.inc
 
-SUB_OBJ=\
-	./build/subroutines/*.o \
+FC_FLAGS := $(OMP) $(COND) $(EXTRA)
+L_FLAGS  := $(OMP) $(LIBS) $(COND) $(EXTRA)
 
+SRC_DIR   := ./src
+BUILD_DIR := ./build
+BIN_DIR   := $(DIR)
+UTILS_DIR := ./utils
 
-SUB_PROGRAM=\
-	./build/subprograms/*.o \
+SUBROUTINE_NAMES := \
+    berry_curvature_subs \
+    boltzmann_subs \
+    bse_subs \
+    bse_subs_kpath \
+    bse_subs_temp \
+    special_funct \
+    ei_spec_funct \
+    coulomb_pot \
+    diel-pp-subs \
+    dos_subs \
+    efmass-subs \
+    general_subs \
+    hamiltonians \
+    hamiltonian_tb \
+    mhkpack_subs \
+    module_input_read \
+    optics \
+    spin_txt_subs \
+    emission_subs \
+    coulomb_pot_gw \
+    gw_subs
 
-																			
+SUBPROGRAM_NAMES := \
+    bands-kpath-tool \
+    berry_curvature_bz-tool \
+    berry_curvature_kpath-tool \
+    bse_diel-tool \
+    bse_diel-tool-pol \
+    bse_kpath-tool \
+    bse_kpath-tool-temp \
+    bse_solver-tool-diel \
+    bse_solver-tool-diel-temp \
+    diel-pp-bse \
+    diel-pp-bse-pol \
+    tdos-tool-stxt \
+    diel-pp \
+    diel-pp-pol \
+    efmass \
+    exciton_lifetime \
+    sp_diel-tool \
+    sp_diel-tool-pol \
+    sp_opt_bz-tool \
+    sp_solver-tool-diel \
+    boltzmann_transport \
+    emission_PL
 
-all : main pp
-	
-pp :
-	$(FOR) ./utils/nc_nv_finder.F90 -o $(DIR)nc_nv_finder.x $(OMP) $(LIBS)
-	$(FOR) ./utils/param_gen.F90  -o $(DIR)param_gen.x
-	$(FOR) ./utils/param_gen_vasp.F90  -o $(DIR)param_gen_vasp.x
-	$(FOR) ./utils/absorbance.F90  -o $(DIR)absorbance.x	
-	$(FOR) ./utils/slme/pce-code.f90 ./utils/slme/pce-subs.f90  -o $(DIR)pce.x
-	$(FOR) ./utils/huckel2wtb/src/overlaps_jc.f90 ./utils/huckel2wtb/src/diagonalize.f90 ./utils/huckel2wtb/src/Huckel_TB.f90 -o $(DIR)huckel2wtb.x $(LIBS)
-	cp ./utils/*.py  $(DIR)
-	rm ./*.mod
+SUBROUTINE_OBJS := $(foreach name,$(SUBROUTINE_NAMES),$(BUILD_DIR)/subroutines/$(name).o)
+SUBPROGRAM_OBJS := $(foreach name,$(SUBPROGRAM_NAMES),$(BUILD_DIR)/subprograms/$(name).o)
 
+MODULE_OBJECTS := $(SUBROUTINE_OBJS) $(SUBPROGRAM_OBJS)
 
-main :  subprograms
-	$(FOR) ./src/wtb_main.F90 $(SUB_OBJ) $(SUB_PROGRAM) -o ./build/wtb.x $(LIBS) $(OMP) $(COND) $(EXTRA) 
-	cp ./build/wtb.x $(DIR)wtb.x
-	rm ./*.mod	
+MAIN_SRC  := $(SRC_DIR)/wtb_main.F90
+MAIN_EXEC := $(BIN_DIR)/wtb.x
 
-subprograms: lib
-	[ -d ./build/subprograms ] || mkdir ./build/subprograms
-	$(FOR) -c ./src/subprograms/bands-kpath-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/berry_curvature_bz-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/berry_curvature_kpath-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_diel-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_diel-tool-pol.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_kpath-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_kpath-tool-temp.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_solver-tool-diel.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/bse_solver-tool-diel-temp.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/diel-pp-bse.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/diel-pp-bse-pol.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/tdos-tool-stxt.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/diel-pp.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/diel-pp-pol.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/efmass.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/exciton_lifetime.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/sp_diel-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/sp_diel-tool-pol.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/sp_opt_bz-tool.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/sp_solver-tool-diel.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/boltzmann_transport.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a
-	$(FOR) -c ./src/subprograms/emission_PL.F90 $(OMP) $(LIBS) $(COND) $(EXTRA) -L./build/libwtb.a	
-	mv *.o ./build/subprograms
+# Define os arquivos-fonte para as regras que têm múltiplos
+PCE_SOURCES := $(UTILS_DIR)/slme/pce-code.f90 $(UTILS_DIR)/slme/pce-subs.f90
+HUCKEL_SOURCES := $(UTILS_DIR)/huckel2wtb/src/overlaps_jc.f90 $(UTILS_DIR)/huckel2wtb/src/diagonalize.f90 $(UTILS_DIR)/huckel2wtb/src/Huckel_TB.f90
 
-lib: subroutines
-	ar rcs ./build/libwtb.a $(SUB_OBJ)
-	 		
-subroutines :
-	[ -d ./build/subroutines ] || mkdir ./build/subroutines
-	$(FOR) -c ./src/subroutines/berry_curvature_subs.F90 
-	$(FOR) -c ./src/subroutines/boltzmann_subs.F90 
-	$(FOR) -c ./src/subroutines/bse_subs.F90 
-	$(FOR) -c ./src/subroutines/bse_subs_kpath.F90 
-	$(FOR) -c ./src/subroutines/bse_subs_temp.F90 
-	$(FOR) -c ./src/subroutines/special_funct.F90
-	$(FOR) -c ./src/subroutines/ei_spec_funct.F90
-	$(FOR) -c ./src/subroutines/coulomb_pot.F90 
-	$(FOR) -c ./src/subroutines/diel-pp-subs.F90 
-	$(FOR) -c ./src/subroutines/dos_subs.F90 
-	$(FOR) -c ./src/subroutines/efmass-subs.F90 
-	$(FOR) -c ./src/subroutines/general_subs.F90 $(LIBS)
-	$(FOR) -c ./src/subroutines/hamiltonians.F90 
-	$(FOR) -c ./src/subroutines/hamiltonian_tb.F90 $(LIBS) $(OMP)
-	$(FOR) -c ./src/subroutines/mhkpack_subs.F90 
-	$(FOR) -c ./src/subroutines/module_input_read.F90 
-	$(FOR) -c ./src/subroutines/optics.F90  
-	$(FOR) -c ./src/subroutines/spin_txt_subs.F90 
-	$(FOR) -c ./src/subroutines/emission_subs.F90	
-	$(FOR) -c ./src/subroutines/coulomb_pot_gw.F90	
-	$(FOR) -c ./src/subroutines/gw_subs.F90
-	mv *.o ./build/subroutines
+all: $(MAIN_EXEC) pp
+	@echo "--- Build Complete ---"
+
+$(MAIN_EXEC): $(MODULE_OBJECTS) $(MAIN_SRC) makefile.inc
+	@mkdir -p $(BIN_DIR)
+	@echo "--- Linking Main Executable: $@ ---"
+	$(FOR) $(MAIN_SRC) $(MODULE_OBJECTS) -o $@ $(L_FLAGS)
+	@cp $@ ./build/wtb.x
+
+$(BUILD_DIR)/subroutines/%.o: $(SRC_DIR)/subroutines/%.F90 makefile.inc
+	@mkdir -p $(dir $@)
+	@echo "Compiling Subroutine: $< -> $@"
+	$(FOR) -c $< -o $@ $(FC_FLAGS)
+
+$(BUILD_DIR)/subprograms/%.o: $(SRC_DIR)/subprograms/%.F90 makefile.inc
+	@mkdir -p $(dir $@)
+	@echo "Compiling Subprogram: $< -> $@"
+	$(FOR) -c $< -o $@ $(FC_FLAGS)
+
+UTILS_EXECS := $(BIN_DIR)/nc_nv_finder.x \
+               $(BIN_DIR)/param_gen.x \
+               $(BIN_DIR)/param_gen_vasp.x \
+               $(BIN_DIR)/absorbance.x \
+               $(BIN_DIR)/pce.x \
+               $(BIN_DIR)/huckel2wtb.x
+
+pp: $(UTILS_EXECS)
+	@echo "--- Copying Python Scripts ---"
+	@cp $(UTILS_DIR)/*.py $(BIN_DIR)
+
+$(BIN_DIR)/nc_nv_finder.x: $(UTILS_DIR)/nc_nv_finder.F90 makefile.inc
+	$(FOR) $< -o $@ $(L_FLAGS)
+
+$(BIN_DIR)/param_gen.x: $(UTILS_DIR)/param_gen.F90 makefile.inc
+	$(FOR) $< -o $@ $(L_FLAGS)
+
+$(BIN_DIR)/param_gen_vasp.x: $(UTILS_DIR)/param_gen_vasp.F90 makefile.inc
+	$(FOR) $< -o $@ $(L_FLAGS)
+
+$(BIN_DIR)/absorbance.x: $(UTILS_DIR)/absorbance.F90 makefile.inc
+	$(FOR) $< -o $@ $(L_FLAGS)
+
+# CORRIGIDO: Usa a variável PCE_SOURCES explícita em vez de $^
+$(BIN_DIR)/pce.x: $(PCE_SOURCES) makefile.inc
+	$(FOR) $(PCE_SOURCES) -o $@ $(L_FLAGS)
+
+# CORRIGIDO: Usa a variável HUCKEL_SOURCES explícita em vez de $^
+$(BIN_DIR)/huckel2wtb.x: $(HUCKEL_SOURCES) makefile.inc
+	$(FOR) $(HUCKEL_SOURCES) -o $@ $(L_FLAGS)
 
 clean:
-	rm -r ./build/subroutines
-	rm -r ./build/subprograms
-	rm -r ./build/wtb.x
-	rm -r ./build/libwtb.a
-	rm  ./bin/*.x	
-	rm  ./bin/*.py	
+	@echo "--- Cleaning build, bin, and .mod files ---"
+	@rm -rf $(BUILD_DIR) $(BIN_DIR) ./*.mod
+	@mkdir -p $(BUILD_DIR) $(BIN_DIR)
 
+$(BUILD_DIR)/subroutines/coulomb_pot.o: $(BUILD_DIR)/subroutines/ei_spec_funct.o
 
-.PHONY : all clean 
+.PHONY: all pp clean

--- a/makefile
+++ b/makefile
@@ -1,12 +1,20 @@
 include makefile.inc
 
-FC_FLAGS := $(OMP) $(COND) $(EXTRA)
-L_FLAGS  := $(OMP) $(LIBS) $(COND) $(EXTRA)
+IS_IFX := $(findstring ifx, $(FOR))
 
 SRC_DIR   := ./src
 BUILD_DIR := ./build
 BIN_DIR   := $(DIR)
 UTILS_DIR := ./utils
+
+ifeq ($(IS_IFX), ifx)
+    MOD_OUT_FLAG := -module $(BUILD_DIR)
+else
+    MOD_OUT_FLAG := -J$(BUILD_DIR)
+endif
+
+FC_FLAGS := $(OMP) $(COND) $(EXTRA) -I$(BUILD_DIR)
+L_FLAGS  := $(OMP) $(LIBS) $(COND) $(EXTRA) -I$(BUILD_DIR)
 
 SUBROUTINE_NAMES := \
     berry_curvature_subs \
@@ -57,14 +65,12 @@ SUBPROGRAM_NAMES := \
 
 SUBROUTINE_OBJS := $(foreach name,$(SUBROUTINE_NAMES),$(BUILD_DIR)/subroutines/$(name).o)
 SUBPROGRAM_OBJS := $(foreach name,$(SUBPROGRAM_NAMES),$(BUILD_DIR)/subprograms/$(name).o)
-
-MODULE_OBJECTS := $(SUBROUTINE_OBJS) $(SUBPROGRAM_OBJS)
+MODULE_OBJECTS  := $(SUBROUTINE_OBJS) $(SUBPROGRAM_OBJS)
 
 MAIN_SRC  := $(SRC_DIR)/wtb_main.F90
 MAIN_EXEC := $(BIN_DIR)/wtb.x
 
-# Define os arquivos-fonte para as regras que têm múltiplos
-PCE_SOURCES := $(UTILS_DIR)/slme/pce-code.f90 $(UTILS_DIR)/slme/pce-subs.f90
+PCE_SOURCES    := $(UTILS_DIR)/slme/pce-code.f90 $(UTILS_DIR)/slme/pce-subs.f90
 HUCKEL_SOURCES := $(UTILS_DIR)/huckel2wtb/src/overlaps_jc.f90 $(UTILS_DIR)/huckel2wtb/src/diagonalize.f90 $(UTILS_DIR)/huckel2wtb/src/Huckel_TB.f90
 
 all: $(MAIN_EXEC) pp
@@ -79,12 +85,12 @@ $(MAIN_EXEC): $(MODULE_OBJECTS) $(MAIN_SRC) makefile.inc
 $(BUILD_DIR)/subroutines/%.o: $(SRC_DIR)/subroutines/%.F90 makefile.inc
 	@mkdir -p $(dir $@)
 	@echo "Compiling Subroutine: $< -> $@"
-	$(FOR) -c $< -o $@ $(FC_FLAGS)
+	$(FOR) -c $< -o $@ $(FC_FLAGS) $(MOD_OUT_FLAG)
 
 $(BUILD_DIR)/subprograms/%.o: $(SRC_DIR)/subprograms/%.F90 makefile.inc
 	@mkdir -p $(dir $@)
 	@echo "Compiling Subprogram: $< -> $@"
-	$(FOR) -c $< -o $@ $(FC_FLAGS)
+	$(FOR) -c $< -o $@ $(FC_FLAGS) $(MOD_OUT_FLAG)
 
 UTILS_EXECS := $(BIN_DIR)/nc_nv_finder.x \
                $(BIN_DIR)/param_gen.x \
@@ -109,17 +115,15 @@ $(BIN_DIR)/param_gen_vasp.x: $(UTILS_DIR)/param_gen_vasp.F90 makefile.inc
 $(BIN_DIR)/absorbance.x: $(UTILS_DIR)/absorbance.F90 makefile.inc
 	$(FOR) $< -o $@ $(L_FLAGS)
 
-# CORRIGIDO: Usa a variável PCE_SOURCES explícita em vez de $^
 $(BIN_DIR)/pce.x: $(PCE_SOURCES) makefile.inc
 	$(FOR) $(PCE_SOURCES) -o $@ $(L_FLAGS)
 
-# CORRIGIDO: Usa a variável HUCKEL_SOURCES explícita em vez de $^
 $(BIN_DIR)/huckel2wtb.x: $(HUCKEL_SOURCES) makefile.inc
 	$(FOR) $(HUCKEL_SOURCES) -o $@ $(L_FLAGS)
 
 clean:
 	@echo "--- Cleaning build, bin, and .mod files ---"
-	@rm -rf $(BUILD_DIR) $(BIN_DIR) ./*.mod
+	@rm -rf $(BUILD_DIR) $(BIN_DIR)
 	@mkdir -p $(BUILD_DIR) $(BIN_DIR)
 
 $(BUILD_DIR)/subroutines/coulomb_pot.o: $(BUILD_DIR)/subroutines/ei_spec_funct.o

--- a/makefile
+++ b/makefile
@@ -69,6 +69,7 @@ MODULE_OBJECTS  := $(SUBROUTINE_OBJS) $(SUBPROGRAM_OBJS)
 
 MAIN_SRC  := $(SRC_DIR)/wtb_main.F90
 MAIN_EXEC := $(BIN_DIR)/wtb.x
+LIB_FILE  := $(BUILD_DIR)/libwtb.a
 
 PCE_SOURCES    := $(UTILS_DIR)/slme/pce-code.f90 $(UTILS_DIR)/slme/pce-subs.f90
 HUCKEL_SOURCES := $(UTILS_DIR)/huckel2wtb/src/overlaps_jc.f90 $(UTILS_DIR)/huckel2wtb/src/diagonalize.f90 $(UTILS_DIR)/huckel2wtb/src/Huckel_TB.f90
@@ -76,11 +77,15 @@ HUCKEL_SOURCES := $(UTILS_DIR)/huckel2wtb/src/overlaps_jc.f90 $(UTILS_DIR)/hucke
 all: $(MAIN_EXEC) pp
 	@echo "--- Build Complete ---"
 
-$(MAIN_EXEC): $(MODULE_OBJECTS) $(MAIN_SRC) makefile.inc
+$(MAIN_EXEC): $(LIB_FILE) $(MAIN_SRC) makefile.inc
 	@mkdir -p $(BIN_DIR)
 	@echo "--- Linking Main Executable: $@ ---"
-	$(FOR) $(MAIN_SRC) $(MODULE_OBJECTS) -o $@ $(L_FLAGS)
+	$(FOR) $(MAIN_SRC) -o $@ $(L_FLAGS) -L$(BUILD_DIR) -lwtb
 	@cp $@ ./build/wtb.x
+
+$(LIB_FILE): $(MODULE_OBJECTS)
+	@echo "--- Creating Static Library: $@ ---"
+	ar rcs $@ $(MODULE_OBJECTS)
 
 $(BUILD_DIR)/subroutines/%.o: $(SRC_DIR)/subroutines/%.F90 makefile.inc
 	@mkdir -p $(dir $@)
@@ -104,26 +109,29 @@ pp: $(UTILS_EXECS)
 	@cp $(UTILS_DIR)/*.py $(BIN_DIR)
 
 $(BIN_DIR)/nc_nv_finder.x: $(UTILS_DIR)/nc_nv_finder.F90 makefile.inc
-	$(FOR) $< -o $@ $(L_FLAGS)
+	$(FOR) $< -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
 
 $(BIN_DIR)/param_gen.x: $(UTILS_DIR)/param_gen.F90 makefile.inc
-	$(FOR) $< -o $@ $(L_FLAGS)
+	$(FOR) $< -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
 
 $(BIN_DIR)/param_gen_vasp.x: $(UTILS_DIR)/param_gen_vasp.F90 makefile.inc
-	$(FOR) $< -o $@ $(L_FLAGS)
+	$(FOR) $< -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
 
 $(BIN_DIR)/absorbance.x: $(UTILS_DIR)/absorbance.F90 makefile.inc
-	$(FOR) $< -o $@ $(L_FLAGS)
+	$(FOR) $< -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
 
 $(BIN_DIR)/pce.x: $(PCE_SOURCES) makefile.inc
-	$(FOR) $(PCE_SOURCES) -o $@ $(L_FLAGS)
+	$(FOR) $(PCE_SOURCES) -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
 
 $(BIN_DIR)/huckel2wtb.x: $(HUCKEL_SOURCES) makefile.inc
-	$(FOR) $(HUCKEL_SOURCES) -o $@ $(L_FLAGS)
+	$(FOR) $(HUCKEL_SOURCES) -o $@ $(L_FLAGS) $(MOD_OUT_FLAG)
+
+	rm -rf $(BUILD_DIR)/*.mod
 
 clean:
 	@echo "--- Cleaning build, bin, and .mod files ---"
 	@rm -rf $(BUILD_DIR) $(BIN_DIR)
+	@rm -f ./*.mod
 	@mkdir -p $(BUILD_DIR) $(BIN_DIR)
 
 $(BUILD_DIR)/subroutines/coulomb_pot.o: $(BUILD_DIR)/subroutines/ei_spec_funct.o

--- a/makefiles/makefile-osx-gcc+openblas+accelerate
+++ b/makefiles/makefile-osx-gcc+openblas+accelerate
@@ -1,0 +1,20 @@
+### If gcc and opeblas are installed via hemebrew, you can use the command below to get the library prefix
+
+OPENBLAS_PREFIX = $(shell brew --prefix openblas)
+
+FOR   = gfortran
+OMP   = -fopenmp
+
+### To use OpenBLAS as a linear algebra library
+LIBS  = -I$(OPENBLAS_PREFIX)/include -L$(OPENBLAS_PREFIX)/lib -lopenblas
+
+### If necessary, use Apple's Accelerate library, which is optimized for M-series ARM chips.
+#LIBS = -framework Accelerate
+
+### For older verssion of GCC
+#EXTRA= -Wno-argument-mismatch -Wargument-mismatch  -Wunderflow -Werror=line-truncation -DOPENBLAS
+
+EXTRA= -Wno-argument-mismatch -Werror=line-truncation -DOPENBLAS
+
+COND  = -cpp -O3 -march=native
+DIR   = ./bin

--- a/makefiles/makefile-osx-gcc+openblas+accelerate
+++ b/makefiles/makefile-osx-gcc+openblas+accelerate
@@ -14,7 +14,7 @@ LIBS  = -I$(OPENBLAS_PREFIX)/include -L$(OPENBLAS_PREFIX)/lib -lopenblas
 ### For older verssion of GCC
 #EXTRA= -Wno-argument-mismatch -Wargument-mismatch  -Wunderflow -Werror=line-truncation -DOPENBLAS
 
-EXTRA= -Wno-argument-mismatch -Werror=line-truncation -DOPENBLAS
+EXTRA= -Wno-argument-mismatch -Wno-underflow -Werror=line-truncation -DOPENBLAS
 
 COND  = -cpp -O3 -march=native
 DIR   = ./bin

--- a/makefiles/makefile_high_perf
+++ b/makefiles/makefile_high_perf
@@ -1,0 +1,9 @@
+FOR=ifx
+OMP=-qopenmp -shared-intel
+LIBS=-qmkl
+EXTRA= -DMKL
+DIR="./bin/"
+
+## -O3 can be used
+
+COND=-fpp -O2 -fp-model fast=2 -xHOST


### PR DESCRIPTION
This pull request updates our build process to make the code run faster on modern computers.

1.  **New Compiler:** We are switching from the old `ifort` compiler to the new `ifx` compiler from Intel.
2.  **Better Optimization:** We are now using the `-xHOST` flag.

---

### **What These Changes Mean**

* **`ifx`**: This is Intel's modern compiler, replacing `ifort` in new versions of Intel OneAPI. It is designed to improve the performance of new CPUs using LLVM as the compiler.
* **`-O3`**: This tells the compiler to optimize the code for maximum speed during compilation. No significant increase in compilation time or memory requirements was identified.
* **`-fp-model fast=2`**: This allows the compiler to perform faster mathematical calculations in certain scenarios.
    * **Warning:** This can cause very small differences in the final numbers, which are often insignificant. In local tests, this was *not* identified, however, further testing is required.
* **`-xHOST`**: This is the most important change. It instructs the compiler to 'look at the CPU I am compiling on and use 100% of its special features'.
    * **Benefits:** This gives you the fastest possible program for your specific machine. For example, it makes use of vectorization flags such as AVX, which the MKL libraries can take advantage of.
    * **Warning:** The program created **will not run on older computers.** It only works on computers that have the same CPU as yours, or a newer one.

---

### **How to Compile for Other Computers**

If you need to compile a program that can run on *other* (or older) computers, you must replace `-xHOST` with a specific flag.

Here are the most common options:

* **For most modern CPUs (Intel & AMD from ~2013+):**
    > Use `-xCORE-AVX2` or `-march=core-avx2`
    > This is the safest, most compatible option for modern hardware.

* **For very new CPUs (Intel & AMD with AVX-512, from ~2022+):**
    > Use `-xCORE-AVX512` or  `-xSKYLAKE-AVX512` or `-march=core-avx2`
    > This is faster but will only run on the very newest machines (like AMD Zen 4 or Intel Sapphire Rapids).


Tests were performed on the following machines:

- MacBook Air M1 (ARM)
- Gentoo GNU/Linux (AMD64, AMD Ryzen 5800X3D)


I will prepare a file containing benchmarks and other statistics.